### PR TITLE
Pi enablement: spawn-comrade --impl pi + token-watch extension (jhs/teos#1577)

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,3 +1,6 @@
 {
-  "extensions": ["../integrations/pi/cccp-comrade.ts"]
+  "extensions": [
+    "../integrations/pi/cccp-comrade.ts",
+    "../integrations/pi/token-watch.ts"
+  ]
 }

--- a/bin/spawn-comrade
+++ b/bin/spawn-comrade
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# spawn-comrade — launch a cccp comrade in a new tmux window.
+# spawn-comrade — launch a cccp comrade in a new tmux window (Claude Code or Pi).
 #
 # Usage:
 #   spawn-comrade -m MODEL -e EFFORT [OPTIONS] NAME SLUG [DOC...]
@@ -9,23 +9,89 @@
 #   DOC...      docs to point the comrade at on join, in order
 #
 # Options:
-#   -m MODEL    Required. claude --model value (e.g. 'claude-opus-4-8[1m]')
-#   -e EFFORT   Required. claude --effort value (low|medium|high|xhigh|max)
+#   --impl IMPL implementation: claude (default) | pi
+#   -m MODEL    Required. A TIER (cheap|normal|premium, mapped per impl) or a raw model id.
+#               No ambient default (#798 fail-closed). Tier map:
+#                 claude → claude-opus-4-8[1m] | claude-opus-5 | claude-fable-5
+#                 pi     → gpt-5.5            | gpt-5.6-terra  | gpt-5.6-sol
+#               (pi's gpt-5.6-luna exists but is UNMAPPED — pass it as a raw id.)
+#   -e EFFORT   Required. claude --effort / pi --thinking value (low|medium|high|xhigh|max).
 #   -s SESSION  tmux session (default: current)
 #   -c CWD      working directory (default: current)
 #   -f ID       Foreman comrade ID for targeted intro on join
-#   --skill SK  cccp skill variant (default: team)
-#   --no-skip   don't pass --dangerously-skip-permissions
+#   --skill SK  cccp skill variant (default: team; claude only)
+#   --no-skip   don't pass --dangerously-skip-permissions (claude only)
 #   --force     allow duplicate window names
+#
+#   Under --impl pi: a [1m] model suffix is refused (claude-only); --resume and token-watch are
+#   not yet implemented; a NONPROD + extension preflight must pass (fails closed with the fix).
 #
 # Observe:  tmux capture-pane -t SESSION:NAME -p | tail -40
 # Retire:   tmux kill-window -t SESSION:NAME
 set -euo pipefail
 
-usage() { sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'; exit 1; }
+usage() { sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 1; }
 
+# ── testable pure-bash surface (#1577) — see tests/test_spawn_comrade.sh ─────────
+
+# map_tier IMPL VALUE → resolved model id. Tier language maps per impl; any other value (a raw id)
+# echoes verbatim. There is deliberately no ambient default: the caller always passes -m (#798).
+map_tier() {
+  local impl=$1 val=$2
+  case "$impl:$val" in
+    claude:cheap)   echo 'claude-opus-4-8[1m]' ;;
+    claude:normal)  echo 'claude-opus-5' ;;
+    claude:premium) echo 'claude-fable-5' ;;
+    pi:cheap)       echo 'gpt-5.5' ;;
+    pi:normal)      echo 'gpt-5.6-terra' ;;
+    pi:premium)     echo 'gpt-5.6-sol' ;;
+    # gpt-5.6-luna exists in pi's catalog but is intentionally left off the tier map — pass it as a
+    # raw id if you want it. Raw ids (either impl) fall through and echo verbatim.
+    *)              echo "$val" ;;
+  esac
+}
+
+# pi_refuse_model MODEL → nonzero if MODEL carries a claude-only affordance under pi.
+pi_refuse_model() {
+  local model=$1
+  if [[ "$model" == *'[1m]'* ]]; then
+    echo "spawn-comrade: the [1m] context suffix is claude-only and has no meaning under --impl pi: $model" >&2
+    return 1
+  fi
+  return 0
+}
+
+# pi_preflight → fail-closed check that this box is set up to run a Pi comrade, and refresh the stable
+# cccp-current symlink the repo .pi/settings.json references. Everything is under $HOME so it is
+# sandbox-testable. On any gap: print the exact fix command and return nonzero (never spawn blind).
+pi_preflight() {
+  local agents="$HOME/.pi/agent/AGENTS.md"
+  if [[ ! -e "$agents" ]]; then
+    echo "spawn-comrade: Pi NONPROD declaration missing — ~/.pi/agent/AGENTS.md is not linked." >&2
+    echo "  Fix: ln -s \"\$PWD/docs/agent-env/NONPROD.md\" ~/.pi/agent/AGENTS.md   (from the repo root)" >&2
+    return 1
+  fi
+  local cache="$HOME/.claude/plugins/cache/CCCP/cccp"
+  local newest=""
+  [[ -d "$cache" ]] && newest="$(ls -1 "$cache" 2>/dev/null | sort -V | tail -1)"
+  if [[ -z "$newest" || ! -f "$cache/$newest/integrations/pi/cccp-comrade.ts" ]]; then
+    echo "spawn-comrade: the cccp Pi extension is not installed under ~/.claude/plugins/cache/CCCP/cccp/<ver>." >&2
+    echo "  Fix: pi install ~/.claude/plugins/cache/CCCP/cccp/<ver>   (install the cccp plugin for Pi)" >&2
+    return 1
+  fi
+  # Stable indirection: the repo .pi/settings.json points at ~/.pi/agent/cccp-current, refreshed to
+  # the newest installed version here (version-sort, newest wins) — so a plugin upgrade needs no edits.
+  ln -sfn "$cache/$newest" "$HOME/.pi/agent/cccp-current"
+  return 0
+}
+
+# Sourced by the test harness for its functions only — define, then return before the launch body.
+[[ -n "${SPAWN_COMRADE_LIB:-}" ]] && return 0
+
+# ── argument parsing ────────────────────────────────────────────────────────────
 session=""
 cwd=""
+impl="claude"
 model=""
 effort=""
 foreman=""
@@ -35,6 +101,7 @@ force=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --impl) [[ $# -ge 2 ]] || { echo "spawn-comrade: --impl needs a value" >&2; exit 1; }; impl="$2"; shift 2 ;;
     -s) [[ $# -ge 2 ]] || { echo "spawn-comrade: -s needs a value" >&2; exit 1; }; session="$2"; shift 2 ;;
     -c) [[ $# -ge 2 ]] || { echo "spawn-comrade: -c needs a value" >&2; exit 1; }; cwd="$2"; shift 2 ;;
     -m|--model) [[ $# -ge 2 ]] || { echo "spawn-comrade: $1 needs a value" >&2; exit 1; }; model="$2"; shift 2 ;;
@@ -54,20 +121,21 @@ done
 name="$1"; slug="$2"; shift 2
 extra_docs=("$@")
 
-[[ -n "$model" ]] || { echo "spawn-comrade: -m/--model is required — pass the comrade's model explicitly; never rely on claude's ambient default" >&2; exit 1; }
-[[ -n "$effort" ]] || { echo "spawn-comrade: -e/--effort is required — pass the comrade's effort explicitly; never rely on claude's ambient default" >&2; exit 1; }
+case "$impl" in claude|pi) ;; *) echo "spawn-comrade: --impl must be claude or pi (got: $impl)" >&2; exit 1 ;; esac
+[[ -n "$model" ]] || { echo "spawn-comrade: -m/--model is required — pass a tier (cheap|normal|premium) or a raw id; never rely on an ambient default" >&2; exit 1; }
+[[ -n "$effort" ]] || { echo "spawn-comrade: -e/--effort is required — pass it explicitly; never rely on an ambient default" >&2; exit 1; }
+
+# Resolve tier → model (raw ids pass through).
+model="$(map_tier "$impl" "$model")"
 
 command -v tmux >/dev/null || { echo "spawn-comrade: tmux not found" >&2; exit 1; }
-command -v claude >/dev/null || { echo "spawn-comrade: claude not found" >&2; exit 1; }
 
-# Default the session to the one we're running inside.
+# ── session + duplicate-window guard (impl-agnostic) ─────────────────────────────
 if [[ -z "$session" ]]; then
   session="$(tmux display-message -p '#S' 2>/dev/null || true)"
   [[ -n "$session" ]] || { echo "spawn-comrade: not inside tmux and no -s given" >&2; exit 1; }
 fi
 tmux has-session -t "$session" 2>/dev/null || { echo "spawn-comrade: no tmux session '$session'" >&2; exit 1; }
-
-# One comrade per role — refuse a duplicate window unless --force.
 if tmux list-windows -t "$session" -F '#W' 2>/dev/null | grep -qxF "$name"; then
   if (( force )); then
     echo "spawn-comrade: window '$name' already exists — spawning anyway (--force)" >&2
@@ -78,33 +146,58 @@ if tmux list-windows -t "$session" -F '#W' 2>/dev/null | grep -qxF "$name"; then
   fi
 fi
 
-# Build the /cccp:<skill> prompt.
-prompt="/cccp:$skill $slug"
-if [[ ${#extra_docs[@]} -gt 0 ]]; then
-  refs="${extra_docs[0]}"
-  for d in "${extra_docs[@]:1}"; do refs+=" then $d"; done
-  prompt+=" # See $refs"
-fi
-if [[ -n "$foreman" ]]; then
-  prompt+=" -- then introduce yourself to your Foreman at ${foreman},"
-else
-  prompt+=" -- then introduce yourself to the cell,"
-fi
-prompt+=" beginning with the literal prefix Intro: followed by your alias ${name}"
-
-# Escape single-quotes for the sh -c string ( ' -> '\'' ).
-esc=${prompt//\'/\'\\\'\'}
-flag=""; (( skip )) && flag=" --dangerously-skip-permissions"
-mflag=" --model '${model//\'/\'\\\'\'}'"
-eflag=" --effort '${effort//\'/\'\\\'\'}'"
-nflag=" --name '${name//\'/\'\\\'\'}'"
-cmd="claude${flag}${mflag}${eflag}${nflag} '${esc}'"
-
 [[ -z "$cwd" ]] && cwd="$(pwd)"
+
+# ── build the launch command, per impl ───────────────────────────────────────────
+if [[ "$impl" == "pi" ]]; then
+  command -v pi >/dev/null || { echo "spawn-comrade: pi not found" >&2; exit 1; }
+  pi_refuse_model "$model" || exit 1
+  pi_preflight || exit 1
+
+  # Pi has no /cccp:<skill> slash-command; it loads the cccp-chat SKILL and drives it in natural
+  # language. Docs become @-file references. The intro ritual is the NON-NEGOTIABLE Comrade.md shape
+  # (#1577): the first message MUST begin with the literal "Comrade Introduction: <Name>", Name the
+  # first bare word — the cell's watchtowers auto-register an alias from exactly that token.
+  docrefs=""
+  for d in "${extra_docs[@]}"; do docrefs+=" @${d}"; done
+  if [[ -n "$foreman" ]]; then intro_target="your Foreman at ${foreman}"; else intro_target="the cell"; fi
+  prompt="Join CCCP cell ${slug} as a comrade using the cccp-chat skill.${docrefs:+ First read these docs:${docrefs}.}"
+  prompt+=" Then introduce yourself to ${intro_target} with a targeted message that begins with the LITERAL prefix"
+  prompt+=" \"Comrade Introduction: ${name}\" — ${name} as the very first bare word, no punctuation attached — followed by your role and comrade id."
+  esc=${prompt//\'/\'\\\'\'}
+  # Export the repo .env and put the cccp bin/ on PATH (the extension also self-locates bin/cccp).
+  bindir="$(cd "$(dirname "$0")" && pwd)"
+  envload=""
+  [[ -f "$cwd/.env" ]] && envload="set -a; . '$cwd/.env'; set +a; "
+  cmd="${envload}export PATH='${bindir}':\"\$PATH\"; pi --provider openai-codex --model '${model//\'/\'\\\'\'}' --thinking '${effort//\'/\'\\\'\'}' --name '${name//\'/\'\\\'\'}' '${esc}'"
+  launchdesc="pi (${model})"
+else
+  command -v claude >/dev/null || { echo "spawn-comrade: claude not found" >&2; exit 1; }
+  # Build the /cccp:<skill> prompt.
+  prompt="/cccp:$skill $slug"
+  if [[ ${#extra_docs[@]} -gt 0 ]]; then
+    refs="${extra_docs[0]}"
+    for d in "${extra_docs[@]:1}"; do refs+=" then $d"; done
+    prompt+=" # See $refs"
+  fi
+  if [[ -n "$foreman" ]]; then
+    prompt+=" -- then introduce yourself to your Foreman at ${foreman},"
+  else
+    prompt+=" -- then introduce yourself to the cell,"
+  fi
+  prompt+=" beginning with the literal prefix Intro: followed by your alias ${name}"
+  esc=${prompt//\'/\'\\\'\'}
+  flag=""; (( skip )) && flag=" --dangerously-skip-permissions"
+  mflag=" --model '${model//\'/\'\\\'\'}'"
+  eflag=" --effort '${effort//\'/\'\\\'\'}'"
+  nflag=" --name '${name//\'/\'\\\'\'}'"
+  cmd="claude${flag}${mflag}${eflag}${nflag} '${esc}'"
+  launchdesc="claude (${model})"
+fi
 
 # Trailing ':' so tmux reads it as the SESSION and picks the next free window index.
 tmux new-window -d -t "${session}:" -n "$name" -c "$cwd" "$cmd"
 
-echo "Spawned '$name' in $session (cell: $slug, skill: $skill)"
+echo "Spawned '$name' [$launchdesc] in $session (cell: $slug)"
 echo "  watch:  tmux capture-pane -t $session:$name -p | tail -40"
 echo "  retire: tmux kill-window -t $session:$name"

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -56,3 +56,19 @@ It needs the `pi` binary plus credentials (an `ANTHROPIC_API_KEY`/`PI_API_KEY` e
 | `CCCP_PLUGIN_DATA` | Optional cccp data directory. Defaults to the Claude plugin's conventional `${CLAUDE_CONFIG_DIR:-~/.claude}/plugins/data/cccp-CCCP` when it exists (a shared store: same-machine Claude and Pi comrades reach the same local-fs cells); on a Claude-less machine, `~/.pi/cccp` is auto-created on first run, announced by a one-time in-session INFO message pointing at the `cccp-setup` skill. |
 
 The cccp binary needs no configuration: the extension uses the `bin/cccp` two directories above its own file (present in any repo or package clone) and prepends that directory to `PATH` at session start, so plain `cccp` works in the model's bash tool from the first turn. The extension's own log appends to `$CCCP_PLUGIN_DATA/logs/pi-comrade.log`.
+
+## Token-watch extension (`token-watch.ts`, #1577)
+
+A second, independent extension: a Pi comrade self-monitors its context window the way a Claude
+comrade runs `claude-tokens watch`. Armed at session start with the Comrade.md thresholds
+(20/50/70/85/92/95 %), it reads pi's own usage feed (`ctx.getContextUsage()`) after each turn and, as
+usage climbs past a threshold, nudges the model once so it can follow the comrade telemetry rules
+(dispatch `Tokens: NN%`). Compaction re-arms the climb. The `token_watch` tool reconfigures the
+thresholds (`{ thresholds: [..] }`; no args re-arms the defaults).
+
+The crossing logic is a pure, dependency-free module (`token-watch-core.ts`) unit-tested at
+`tests/test_token_watch.ts` (`node --experimental-strip-types --test`); `token-watch.ts` is only the
+pi wiring (`turn_end` / `session_compact` / `registerTool`).
+
+Load it alongside the comrade extension via the same `.pi/settings.json` `extensions` list (this
+repo does; a consuming repo lists both files through its `cccp-current` symlink).

--- a/integrations/pi/token-watch-core.ts
+++ b/integrations/pi/token-watch-core.ts
@@ -1,0 +1,61 @@
+/**
+ * token-watch-core.ts — the pure, dependency-free crossing logic for the Pi token-watch extension
+ * (#1577). No pi/typebox imports, so it unit-tests without loading the agent runtime.
+ *
+ * A Pi comrade self-monitors its context window the way a Claude comrade runs `claude-tokens watch`:
+ * as usage climbs past each threshold it is nudged once, and the comrade telemetry rules (Comrade.md)
+ * decide what to do (dispatch `Tokens: NN%`). This module owns only the "which thresholds did we just
+ * cross" decision; the extension wires it to pi's usage feed and the nudge.
+ */
+
+/** Comrade.md telemetry thresholds (#1577), percent of the context window. */
+export const DEFAULT_THRESHOLDS = [20, 50, 70, 85, 92, 95];
+
+export class TokenWatch {
+  private thresholds: number[];
+  private fired = new Set<number>();
+
+  constructor(thresholds: number[] = DEFAULT_THRESHOLDS) {
+    this.thresholds = normalizeThresholds(thresholds);
+  }
+
+  /** Replace the armed thresholds; already-fired state for any surviving threshold is preserved so a
+   *  reconfigure never re-fires a threshold already reported this fill. */
+  arm(thresholds: number[]): void {
+    this.thresholds = normalizeThresholds(thresholds);
+    // Drop fired marks for thresholds no longer armed (keeps the set from growing unbounded).
+    for (const t of [...this.fired]) if (!this.thresholds.includes(t)) this.fired.delete(t);
+  }
+
+  /** Context dropped (compaction) — re-arm every threshold so the climb can be reported again. */
+  reset(): void {
+    this.fired.clear();
+  }
+
+  armed(): number[] {
+    return [...this.thresholds];
+  }
+
+  /**
+   * Given the current usage percent, return the armed thresholds newly crossed by it (ascending),
+   * marking them fired so each fires at most once per fill. A null/negative percent (unknown usage,
+   * e.g. right after compaction) crosses nothing.
+   */
+  crossed(percent: number | null): number[] {
+    if (percent == null || !Number.isFinite(percent) || percent < 0) return [];
+    const now: number[] = [];
+    for (const t of this.thresholds) {
+      if (percent >= t && !this.fired.has(t)) {
+        this.fired.add(t);
+        now.push(t);
+      }
+    }
+    return now;
+  }
+}
+
+/** De-dupe, drop out-of-range/non-finite entries, and sort ascending. */
+export function normalizeThresholds(thresholds: number[]): number[] {
+  const clean = thresholds.filter((t) => Number.isFinite(t) && t > 0 && t <= 100);
+  return [...new Set(clean)].sort((a, b) => a - b);
+}

--- a/integrations/pi/token-watch.ts
+++ b/integrations/pi/token-watch.ts
@@ -1,0 +1,65 @@
+/**
+ * token-watch.ts — Pi extension (#1577): a comrade self-monitors its context window the way a Claude
+ * comrade runs `claude-tokens watch`. Armed with the Comrade.md thresholds at session start; after
+ * each turn it reads pi's own usage feed (ctx.getContextUsage()) and, as usage climbs past a
+ * threshold, nudges the model once so it can follow the comrade telemetry rules (dispatch
+ * `Tokens: NN%`). Compaction re-arms the climb. A `token_watch` tool reconfigures the thresholds.
+ *
+ * Pure crossing logic is in token-watch-core.ts (unit-tested); this file is only the pi wiring.
+ */
+import { Type } from "typebox";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { TokenWatch, DEFAULT_THRESHOLDS } from "./token-watch-core.ts";
+
+export default function (pi: ExtensionAPI) {
+  // Auto-armed with the defaults — self-monitoring out of the box, no tool call required.
+  const watch = new TokenWatch();
+
+  // After each turn, check usage and nudge once per newly-crossed threshold.
+  pi.on("turn_end", (_event, ctx) => {
+    const pct = ctx.getContextUsage?.()?.percent ?? null;
+    const crossed = watch.crossed(pct);
+    if (crossed.length === 0 || pct == null) return;
+    const hit = Math.max(...crossed);
+    const rounded = Math.round(pct);
+    pi.sendMessage(
+      {
+        customType: "cccp-token-watch",
+        content:
+          `CCCP token-watch: your context window is at ${rounded}% (crossed the ${hit}% threshold). ` +
+          `Per your comrade telemetry rules, report it now — a one-line "Tokens: ${rounded}%" at each ` +
+          `threshold, and the fuller capacity report at the top thresholds — then keep working.`,
+        display: true,
+      },
+      { deliverAs: "followUp", triggerTurn: true },
+    );
+  });
+
+  // Compaction dropped the context — the percent falls, so re-arm every threshold for the new climb.
+  pi.on("session_compact", () => watch.reset());
+
+  // Reconfigure the watch (same threshold semantics as `claude-tokens watch --threshold`).
+  pi.registerTool({
+    name: "token_watch",
+    label: "Token Watch",
+    description:
+      "Arm or reconfigure this session's context-window threshold watch. With no args it re-arms the " +
+      "Comrade.md defaults; pass `thresholds` (percent values) to override. Crossings are reported to " +
+      "you automatically as usage climbs — you do not poll this tool.",
+    parameters: Type.Object({
+      thresholds: Type.Optional(
+        Type.Array(Type.Number(), {
+          description: "Percent thresholds to watch, e.g. [20,50,70,85,92,95]; omitted or empty = the defaults.",
+        }),
+      ),
+    }),
+    async execute(_toolCallId: string, params: { thresholds?: number[] }) {
+      watch.arm(params.thresholds && params.thresholds.length ? params.thresholds : DEFAULT_THRESHOLDS);
+      const armed = watch.armed().join(", ");
+      return {
+        content: [{ type: "text" as const, text: `Token-watch armed at ${armed}%. Crossings are reported automatically as usage climbs.` }],
+        details: { thresholds: watch.armed() },
+      };
+    },
+  });
+}

--- a/tests/test_spawn_comrade.sh
+++ b/tests/test_spawn_comrade.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# test_spawn_comrade.sh — unit tests for spawn-comrade's PURE-BASH surface (#1577): the impl/tier
+# model map, the fail-closed Pi preflight (NONPROD declaration + extension + the cccp-current symlink
+# refresh), and the Pi-refusal guards. No tmux, no claude/pi launch — the script is SOURCED and its
+# functions are called directly against a sandbox HOME, the ssh-prod.test.sh pattern.
+#
+# RAN= discipline: every assertion increments RAN; a silent match-nothing is a fail, not a pass. The
+# RAN count + the fail total are the signal, not the absence of red.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../bin/spawn-comrade"
+RAN=0; FAIL=0
+ok()   { RAN=$((RAN+1)); }
+fail() { RAN=$((RAN+1)); FAIL=$((FAIL+1)); echo "FAIL: $*" >&2; }
+eq()   { if [[ "$1" == "$2" ]]; then ok; else fail "${3:-eq}: expected [$2] got [$1]"; fi; }
+ne()   { if [[ "$1" != "$2" ]]; then ok; else fail "${3:-ne}: unexpected [$1]"; fi; }
+
+# Source the script for its functions only — SPAWN_COMRADE_LIB=1 must make it define + return before
+# the main body (no tmux/launch on source). If sourcing runs main, that itself is the first failure.
+export SPAWN_COMRADE_LIB=1
+# shellcheck disable=SC1090
+source "$SCRIPT" || { echo "FAIL: could not source $SCRIPT (is the SPAWN_COMRADE_LIB guard present?)" >&2; echo "RAN=0"; exit 1; }
+set +e  # spawn-comrade sets -euo pipefail; we test nonzero returns deliberately, so drop -e here
+
+# ── map_tier: tier language → per-impl model, raw ids pass through ──────────────
+eq "$(map_tier claude cheap)"   "claude-opus-4-8[1m]" "claude/cheap"
+eq "$(map_tier claude normal)"  "claude-opus-5"       "claude/normal"
+eq "$(map_tier claude premium)" "claude-fable-5"      "claude/premium"
+eq "$(map_tier pi cheap)"       "gpt-5.5"             "pi/cheap"
+eq "$(map_tier pi normal)"      "gpt-5.6-terra"       "pi/normal"
+eq "$(map_tier pi premium)"     "gpt-5.6-sol"         "pi/premium"
+# Raw ids pass through unchanged for either impl (no ambient default; #798).
+eq "$(map_tier pi gpt-5.6-luna)"        "gpt-5.6-luna"        "pi/raw-luna-passthrough"
+eq "$(map_tier pi gpt-5.6-sol)"         "gpt-5.6-sol"         "pi/raw-passthrough"
+eq "$(map_tier claude claude-opus-5)"   "claude-opus-5"       "claude/raw-passthrough"
+# A claude tier is NOT silently valid as a pi model and vice-versa is only via raw id — tiers are the
+# only cross-impl vocabulary; a raw id is echoed verbatim regardless of impl.
+eq "$(map_tier pi claude-opus-5)"       "claude-opus-5"       "pi/raw-claude-id-verbatim"
+
+# ── pi_refuse: claude-only flags rejected under --impl pi ──────────────────────
+# A [1m] context suffix is claude-only; refuse it on a pi model.
+if pi_refuse_model "gpt-5.6-sol[1m]" 2>/dev/null; then fail "pi_refuse_model should reject [1m] suffix"; else ok; fi
+if pi_refuse_model "gpt-5.6-sol"     2>/dev/null; then ok; else fail "pi_refuse_model rejected a clean pi model"; fi
+
+# ── pi_preflight: fail-closed on missing NONPROD declaration / missing extension ─
+SANDBOX="$(mktemp -d)"; trap 'rm -rf "$SANDBOX"' EXIT
+export HOME="$SANDBOX"
+mkdir -p "$SANDBOX/.pi/agent"
+# (a) no AGENTS.md symlink, no extension install → fail closed, nonzero, names the fix.
+out="$(pi_preflight 2>&1)"; rc=$?
+ne "$rc" "0" "preflight/no-agents rc"
+if grep -qiE "AGENTS\.md|NONPROD|symlink" <<<"$out"; then ok; else fail "preflight should name the AGENTS.md/NONPROD fix"; fi
+
+# (b) AGENTS.md present but NO installed cccp plugin → still fail closed on the extension.
+ln -s /dev/null "$SANDBOX/.pi/agent/AGENTS.md"
+out="$(pi_preflight 2>&1)"; rc=$?
+ne "$rc" "0" "preflight/no-extension rc"
+if grep -qiE "install|extension|plugins/cache/CCCP" <<<"$out"; then ok; else fail "preflight should name the extension install fix"; fi
+
+# (c) both present → succeeds AND refreshes ~/.pi/agent/cccp-current to the NEWEST installed version.
+mkdir -p "$SANDBOX/.claude/plugins/cache/CCCP/cccp/3.2.0/integrations/pi" \
+         "$SANDBOX/.claude/plugins/cache/CCCP/cccp/3.3.0/integrations/pi" \
+         "$SANDBOX/.claude/plugins/cache/CCCP/cccp/3.10.0/integrations/pi"
+touch "$SANDBOX/.claude/plugins/cache/CCCP/cccp/3.10.0/integrations/pi/cccp-comrade.ts"
+out="$(pi_preflight 2>&1)"; rc=$?
+eq "$rc" "0" "preflight/ok rc"
+# version-sort: 3.10.0 > 3.3.0 > 3.2.0 (NOT lexical, where 3.3.0 > 3.10.0)
+target="$(readlink "$SANDBOX/.pi/agent/cccp-current" 2>/dev/null)"
+eq "$target" "$SANDBOX/.claude/plugins/cache/CCCP/cccp/3.10.0" "cccp-current → newest version"
+
+echo "RAN=$RAN FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test_token_watch.ts
+++ b/tests/test_token_watch.ts
@@ -1,0 +1,56 @@
+// test_token_watch.ts — unit tests for the Pi token-watch crossing logic (#1577). Pure module, no
+// pi runtime; run with:  node --experimental-strip-types --test tests/test_token_watch.ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { TokenWatch, DEFAULT_THRESHOLDS, normalizeThresholds } from "../integrations/pi/token-watch-core.ts";
+
+test("each armed threshold fires at most once, ascending, as usage climbs", () => {
+  const w = new TokenWatch([20, 50, 92]);
+  assert.deepEqual(w.crossed(10), []);            // below all
+  assert.deepEqual(w.crossed(20), [20]);          // hits the first
+  assert.deepEqual(w.crossed(35), []);            // still past 20, nothing new
+  assert.deepEqual(w.crossed(55), [50]);          // next
+  assert.deepEqual(w.crossed(55), []);            // idempotent at the same level
+});
+
+test("a jump past several thresholds fires all of them at once, ascending", () => {
+  const w = new TokenWatch([20, 50, 70, 85, 92, 95]);
+  assert.deepEqual(w.crossed(93), [20, 50, 70, 85, 92]);
+  assert.deepEqual(w.crossed(96), [95]);
+});
+
+test("unknown usage (null / negative / NaN) crosses nothing", () => {
+  const w = new TokenWatch([50]);
+  assert.deepEqual(w.crossed(null), []);
+  assert.deepEqual(w.crossed(-1), []);
+  assert.deepEqual(w.crossed(Number.NaN), []);
+  assert.deepEqual(w.crossed(50), [50]); // still armed after the no-ops
+});
+
+test("reset() re-arms all thresholds — a post-compaction climb reports again", () => {
+  const w = new TokenWatch([50, 92]);
+  assert.deepEqual(w.crossed(95), [50, 92]);
+  assert.deepEqual(w.crossed(95), []);   // fired
+  w.reset();                              // compaction dropped the context
+  assert.deepEqual(w.crossed(60), [50]);  // fires again on the new climb
+  assert.deepEqual(w.crossed(95), [92]);
+});
+
+test("arm() reconfigures: keeps fired for surviving thresholds, drops removed ones", () => {
+  const w = new TokenWatch([50, 92]);
+  assert.deepEqual(w.crossed(93), [50, 92]);
+  w.arm([50, 70, 92]);                    // 70 added, 50/92 survive (already fired)
+  assert.deepEqual(w.armed(), [50, 70, 92]);
+  assert.deepEqual(w.crossed(93), [70]);  // only the newly-armed 70 fires; 50/92 stay fired
+});
+
+test("defaults are the Comrade.md thresholds", () => {
+  assert.deepEqual(new TokenWatch().armed(), DEFAULT_THRESHOLDS);
+  assert.deepEqual(DEFAULT_THRESHOLDS, [20, 50, 70, 85, 92, 95]);
+});
+
+test("normalizeThresholds de-dupes, sorts ascending, drops out-of-range/non-finite", () => {
+  assert.deepEqual(normalizeThresholds([92, 20, 50, 20]), [20, 50, 92]);
+  assert.deepEqual(normalizeThresholds([0, 101, -5, 50, Number.NaN, Infinity]), [50]);
+  assert.deepEqual(normalizeThresholds([100]), [100]); // 100 is in range (inclusive)
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "nodenext",
     "strict": true,
     "skipLibCheck": true,
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["integrations/pi/**/*.ts"]
 }


### PR DESCRIPTION
Pi-enablement builds 1 + 3 for `spawn-comrade` and the Pi comrade extension, from jhs/teos#1577. Two commits; teos (jhs/teos) is the consumer.

## Build 1 — `spawn-comrade --impl pi` (`bin/spawn-comrade`)
- `--impl claude|pi` (default claude). `-m` takes a tier (cheap|normal|premium, mapped per impl) or a raw id; no ambient default. Tier map: claude → opus-4-8[1m]|opus-5|fable-5; pi → gpt-5.5|gpt-5.6-terra|gpt-5.6-sol (gpt-5.6-luna left off the map on purpose, noted).
- `-e` → claude `--effort` / pi `--thinking`. The pi branch builds the proven `pi --provider openai-codex --model --thinking --name @docs "<prompt>"` invocation with the repo `.env` exported and `bin/` on PATH.
- Fail-closed pi preflight (NONPROD `~/.pi/agent/AGENTS.md` + installed cccp extension, each with its exact fix command) that also refreshes a stable `~/.pi/agent/cccp-current` symlink to the newest installed version (version-sort) — so a consuming repo's `.pi/settings.json` needs no edit across upgrades. `[1m]` refused under pi; `--resume`/token-watch documented-unimplemented.
- Test-first: `tests/test_spawn_comrade.sh` (RAN=18/0; sourced via a `SPAWN_COMRADE_LIB` guard, ssh-prod pattern) covers the tier map, the fail-closed preflight + symlink refresh, and the refusal.
- **Maintainer call:** the pi intro forces the `Comrade Introduction: <Name>` literal (what the consuming cell's alias auto-registration keys on) while the claude branch's existing default prefix is `Intro:`. The two now differ — unify or not is your call.

## Build 3 — Pi token-watch extension (`integrations/pi/token-watch{,-core}.ts`)
- A Pi comrade self-monitors its context window like `claude-tokens watch`, from pi's own usage feed (`ctx.getContextUsage().percent`) — armed at session start with the Comrade.md thresholds (20/50/70/85/92/95), nudging the model once per crossed threshold on `turn_end`, re-arming on `session_compact`; a `token_watch` tool reconfigures.
- Pure crossing logic split into `token-watch-core.ts`, unit-tested at `tests/test_token_watch.ts` (`node --experimental-strip-types --test`, 7/7).
- `tsconfig`: `allowImportingTsExtensions` (noEmit already set) for the `.ts` sibling import.
- **Maintainer note:** `package.json` `pi.extensions` points at the `./integrations/pi` DIR; `resolveExtensionEntries` returns null for a dir with no index.ts/package.json, so today the project `.pi/settings.json` file-list is what loads these. If the install path should auto-load both extensions, the manifest needs the files listed — left unchanged here to avoid altering install behavior blind.

## Verification
`tsc --noEmit` clean; `tests/test_token_watch.ts` 7/7; `tests/test_spawn_comrade.sh` 18/0; `tests/test_cccp.py` OK. The 4 `test_pi_comrade.py` failures are pre-existing on main (verified by stashing this branch) — env-surface tests, untouched here.

## teos consumption
teos ships `.pi/settings.json` (merged: jhs/teos 325de4d3) pointing at `~/.pi/agent/cccp-current`, and its Foreman spawns Pi comrades with `spawn-comrade --impl pi`. A teos follow-up adds the token-watch file to that settings list once this releases.

Reviewer posts the gate verdict here; merge + version-cut are the maintainer's (per the two-repo flow).

By **BuilderGate** `co@fs:4d76a8`
