### PR TITLE
Reduce Pi event turn overhead

### DIFF
--- a/.pi/skills/cccp-chat/SKILL.md
+++ b/.pi/skills/cccp-chat/SKILL.md
@@ -11,19 +11,19 @@ You are a **comrade** in a CCCP **cell**: a named chat room shared with other AI
 
 Your comrade id is fixed for the whole session, before any join: it is in env from session start — `echo $CCCP_COMRADE_ID` with bash. The `cccp_join` result repeats it, and each joined cell's `ready <your-id> slug=<slug> v=<version>` event confirms the listener. Remember your id and every joined slug.
 
-Comrade ids look like `user@host:abc123` — `user@host` says which machine/account, the suffix separates sibling sessions. You need both values constantly below: the slug is every CLI command's first argument (`<slug>`), and your id is how you recognize a DM. The CLI is plain `cccp` — the extension puts it on your bash tool's PATH at session start, so `cccp config` works even before joining — and each incoming event's preamble spells out the exact command to run, so prefer what it says.
+Comrade ids look like `user@host:abc123` — `user@host` says which machine/account, the suffix separates sibling sessions. You need both values constantly below: the slug is every CLI command's first argument (`<slug>`), and your id is how you recognize a DM. The CLI is plain `cccp` — the extension puts it on your bash tool's PATH at session start, so `cccp config` works even before joining.
 
 A session may join several cells; every cell event names its slug, and every dispatch and CLI command targets one explicit cell.
 
 ## Receiving
 
-The cccp-comrade extension runs your listener (the **watchtower**) from the moment `cccp_join` succeeds — never start one yourself. Cell events arrive as messages labeled `CCCP cell event`, one event per line, formatted `eventtype key1=val1 key2=val2 ...`:
+The cccp-comrade extension runs your listener (the **watchtower**) from the moment `cccp_join` succeeds — never start one yourself. `cccp_join` supplies the one-time reply and truncation guidance; subsequent cell events arrive as concise messages labeled `CCCP cell event`: `cccp <slug>: eventtype key1=val1 key2=val2 ...`.
 
 | Event | Meaning |
 |---|---|
 | `ready <you> slug=<slug> v=<ver>` | Startup confirmation — the watchtower is live. |
 | `message from=<id> ts=<ts> to=<ids> body="..."` | A message. `to=*` is a broadcast; your exact id is a DM. `body` is a JSON-encoded string (multi-line content arrives as one line). |
-| `... chars=N truncated=true preview="..."` | Body too long for one line. Act on the preview when it suffices; otherwise read the continuation with the read command the event preamble gives you (its `<slug>` is already filled in — substitute only sender and ts). The output starts with a marker like `[…from char 372]` and continues from exactly where the preview stopped. |
+| `... chars=N truncated=true preview="..."` | Body too long for one line. Act on the preview when it suffices; otherwise read the continuation with `cccp read <slug> --from <sender> --ts <ts>`. The output starts with a marker like `[…from char 372]` and continues from exactly where the preview stopped. |
 | `filesystem from=<id> op=publish path=... local=<path>` | A shared file, already downloaded to `local=` — read it there, never at the sender's original path. Without `local=`: too big for auto-download; fetch on demand with `cccp pull <slug> <path>`. |
 | `idle quiet=<dur>` | Healthy silence — the line is quiet, nothing is required of you. |
 | `deadline comrade=<id> result=met\|missed ...` | A response deadline you set was met or missed. |
@@ -46,7 +46,7 @@ For history and files use bash: `cccp read <slug> [--from <id>] [--last N | --ts
 ## On invocation
 
 1. Determine the cell slug: the first token of your user's arguments, or an obvious slug from context. If you have neither, ask your user which cell to join before doing anything else.
-2. Call the **cccp_join tool** with that slug. Its result gives your comrade id; the `ready` event confirms the listener.
+2. Call the **cccp_join tool** with that slug. Its result gives your comrade id; the `ready` event confirms the listener. To suppress idle heartbeats, pass `idle_minutes: 0`; omit it to use cccp's default.
 3. Briefly tell your user you've joined and quote your comrade id. No cell-wide hello — there are no join events, so other comrades discover you when your first message arrives.
 4. Act on your user's instructions; otherwise participate as cell events arrive.
 

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -18,7 +18,7 @@ Then join from inside the session — membership is agent-driven, exactly like C
 /skill:cccp-chat <slug> <optional role/context>
 ```
 
-The skill has the model call the `cccp_join` tool with the slug; no watchtower runs until then. Sessions that never join stay dormant apart from the session-start environment resolution below, which is what makes `cccp config` (and the comrade id) available before any join.
+The skill has the model call the `cccp_join` tool with the slug; no watchtower runs until then. Sessions that never join stay dormant apart from the session-start environment resolution below, which is what makes `cccp config` (and the comrade id) available before any join. Pass optional `idle_minutes: 0` to `cccp_join` to disable idle heartbeats; omit it to retain cccp's default interval.
 
 Installed (the repo is a pi package — see the root `package.json` `pi` manifest):
 
@@ -35,6 +35,10 @@ The doctrine half lives in a Pi skill, `.pi/skills/cccp-chat/` (also shipped via
 ```
 
 The split vs Claude Code: there the chat skill both instructs the model AND arms the watchtower (Monitor tool); under Pi the extension owns all plumbing, so the skill is pure instruction.
+
+## Event delivery
+
+`cccp_join` returns the one-time instructions for replying to events and reading a truncated event. After that, each event turn is only `cccp <slug>: <raw event line>`, keeping multi-cell sessions identifiable without repeating the standing guidance.
 
 ## Testing
 

--- a/integrations/pi/cccp-comrade.ts
+++ b/integrations/pi/cccp-comrade.ts
@@ -20,7 +20,7 @@
  *
  *   cccp_join         Membership, per cell. The cell slug is always a tool argument — never env, never session
  *                     state. A session may join any number of cells (or none: sessions that never join stay
- *                     dormant). Each join spawns `cccp watchtower <slug>` and injects its stdout lines into the
+ *                     dormant). Each join spawns `cccp watchtower <slug>` (optionally `--idle <minutes>`) and injects its stdout lines into the
  *                     session via pi.sendMessage({deliverAs: "followUp", triggerTurn: true}) — the same
  *                     full-parity behavior a Claude Code comrade gets from the Monitor tool. Telemetry lines
  *                     (ready/idle/alias/shutdown) are delivered too; emission policy belongs to cccp's own knobs
@@ -116,13 +116,14 @@ export function resolveEnvironment(sessionId: string | undefined): EnvResolution
 	return { created, problem: null };
 }
 
-function eventPreamble(slug: string, line: string): string {
-	return (
-		`CCCP cell event on '${slug}' (from the cell's shared watchtower; body= values are JSON-encoded strings). ` +
-		`If a reply carries content, use the cccp_dispatch tool with cell '${slug}' targeted to the sender; telemetry lines (ready/idle/alias/shutdown) need no reply. ` +
-		`For a line with truncated=true, read the remainder with the bash tool: cccp read ${slug} --from <sender> --ts <ts>\n` +
-		line
-	);
+/** Concise event turn: joining supplies the one-time handling guidance. */
+export function eventMessage(slug: string, line: string): string {
+	return `cccp ${slug}: ${line}`;
+}
+
+/** Omit --idle to preserve cccp's default; zero explicitly disables heartbeats. */
+export function watchtowerArgs(cell: string, idleMinutes?: number): string[] {
+	return ["watchtower", cell, ...(idleMinutes === undefined ? [] : ["--idle", String(idleMinutes)])];
 }
 
 type ComradeState = {
@@ -179,8 +180,9 @@ export default function (pi: ExtensionAPI) {
 			"Join a CCCP cell (a chat room shared with other AI agents) as a comrade. Starts a listener for that cell; its incoming events then arrive automatically as messages. A session may join any number of cells.",
 		parameters: Type.Object({
 			cell: Type.String({ description: "Cell slug to join — lowercase, hyphenated, shell-safe, e.g. 'demo-cell'" }),
+			idle_minutes: Type.Optional(Type.Integer({ minimum: 0, description: "Minutes before idle heartbeats; 0 disables them. Omit for cccp's default." })),
 		}),
-		async execute(_toolCallId: string, params: { cell: string }) {
+		async execute(_toolCallId: string, params: { cell: string; idle_minutes?: number }) {
 			const cell = params.cell;
 			if (state.towers.has(cell)) {
 				return { content: [{ type: "text" as const, text: `Already joined cell '${cell}' as ${process.env.CCCP_COMRADE_ID}` }], details: { cell } };
@@ -193,12 +195,12 @@ export default function (pi: ExtensionAPI) {
 			}
 			log("INFO", `Join cell ${cell} as comrade: ${process.env.CCCP_COMRADE_ID}`);
 			const stderrTail: string[] = [];
-			const tower = spawn(CCCP, ["watchtower", cell], { stdio: ["ignore", "pipe", "pipe"] });
+			const tower = spawn(CCCP, watchtowerArgs(cell, params.idle_minutes), { stdio: ["ignore", "pipe", "pipe"] });
 			state.towers.set(cell, tower);
 			readline.createInterface({ input: tower.stdout! }).on("line", (line) => {
 				log("INFO", `Cell ${cell} event: ${JSON.stringify(line)}`);
 				pi.sendMessage(
-					{ customType: "cccp-event", content: eventPreamble(cell, line), display: true },
+					{ customType: "cccp-event", content: eventMessage(cell, line), display: true },
 					{ deliverAs: "followUp", triggerTurn: true },
 				);
 			});
@@ -228,7 +230,7 @@ export default function (pi: ExtensionAPI) {
 				);
 			});
 			return {
-				content: [{ type: "text" as const, text: `Joined cell '${cell}' as ${process.env.CCCP_COMRADE_ID}. The ready event confirms the listener; cell events arrive automatically from now on.` }],
+				content: [{ type: "text" as const, text: `Joined cell '${cell}' as ${process.env.CCCP_COMRADE_ID}. The ready event confirms the listener; cell events arrive automatically from now on. Reply only when a reply carries content, using cccp_dispatch targeted to the sender; ready, idle, alias, and shutdown events need no reply. For truncated=true, read the remainder with: cccp read ${cell} --from <sender> --ts <ts>.` }],
 				details: { cell },
 			};
 		},

--- a/tests/test_pi_comrade.py
+++ b/tests/test_pi_comrade.py
@@ -256,6 +256,44 @@ class EnvSurface(unittest.TestCase):
                              "must not create ~/.pi/cccp when the Claude dir exists")
 
 
+class EventSurface(unittest.TestCase):
+    """A joined Pi comrade gets concise event turns and an explicit idle knob."""
+
+    def _extension_values(self):
+        script = (
+            'import("./integrations/pi/cccp-comrade.ts").then(m => {'
+            '  console.log(JSON.stringify({'
+            '    event: m.eventMessage("second-cell", "idle quiet=30m"),'
+            '    defaultArgs: m.watchtowerArgs("second-cell"),'
+            '    disabledArgs: m.watchtowerArgs("second-cell", 0)'
+            '  }));'
+            '}, e => { console.error(e.message); process.exit(1); });'
+        )
+        with tempfile.TemporaryDirectory() as td:
+            env = dict(os.environ, CCCP_PLUGIN_DATA=td)
+            r = subprocess.run(["node", "--no-warnings", "-e", script], cwd=REPO,
+                               env=env, capture_output=True, text=True, timeout=60)
+        if r.returncode != 0 and "Unknown file extension" in r.stderr + r.stdout:
+            self.skipTest("SKIPPED LOUDLY: this node cannot import TypeScript "
+                          "natively (needs Node >= 23) - event-surface test not run")
+        self.assertEqual(r.returncode, 0, f"node failed:\n{r.stderr}")
+        return json.loads(r.stdout.strip().splitlines()[-1])
+
+    def test_event_turn_is_raw_line_without_repeated_preamble(self):
+        out = self._extension_values()
+        self.assertIn("idle quiet=30m", out["event"])
+        self.assertNotIn("CCCP cell event on 'second-cell'", out["event"])
+        self.assertEqual(out["event"], "cccp second-cell: idle quiet=30m")
+
+    def test_idle_zero_reaches_watchtower_and_default_stays_unchanged(self):
+        out = self._extension_values()
+        self.assertEqual(out["defaultArgs"], ["watchtower", "second-cell"])
+        self.assertEqual(out["disabledArgs"], ["watchtower", "second-cell", "--idle", "0"])
+        self.assertIn('spawn(CCCP, watchtowerArgs(cell, params.idle_minutes)',
+                      EXTENSION.read_text(),
+                      "cccp_join must pass its idle_minutes through to the spawned watchtower")
+
+
 class TypeCheck(unittest.TestCase):
     def test_extension_typechecks(self):
         if not (REPO / "node_modules" / ".bin" / "tsc").exists():


### PR DESCRIPTION
## Summary
- deliver event-handling guidance once when joining
- keep event turns to a cell prefix and raw event line
- add an optional idle-heartbeat override

## Validation
- python3 -m unittest discover -s tests -v